### PR TITLE
chore: Python パッケージ管理を pip から uv に移行

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,13 +10,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
         with:
           python-version: '3'
 
       - name: Install dependencies
-        run: pip install -r app/requirements.txt -r app/requirements-test.txt
+        run: uv pip install --system -r app/requirements.txt -r app/requirements-test.txt
 
       - name: Run pytest
         run: pytest app/

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,10 +16,12 @@ jobs:
           python-version: '3'
 
       - name: Install dependencies
-        run: uv pip install --system -r app/requirements.txt -r app/requirements-test.txt
+        run: |
+          uv venv
+          uv pip install -r app/requirements.txt -r app/requirements-test.txt
 
       - name: Run pytest
-        run: pytest app/
+        run: uv run pytest app/
 
   lint:
     name: Lint Dockerfile with hadolint

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3
+COPY --from=ghcr.io/astral-sh/uv:0.11.8 /uv /bin/uv
 RUN apt-get update \
   && apt-get upgrade -y \
   && apt-get -y clean \
@@ -7,7 +8,7 @@ RUN groupadd app && useradd -g app app
 RUN mkdir /app && chown app:app /app
 COPY app/* /app/
 WORKDIR /app
-RUN pip install --no-cache-dir -r requirements.txt
+RUN uv pip install --system --no-cache -r requirements.txt
 ENV FLASK_APP=app.py
 USER app
 CMD ["flask", "run", "--host=0.0.0.0"]

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -3,6 +3,4 @@ Flask==3.1.3
 itsdangerous==2.2.0
 Jinja2==3.1.6
 MarkupSafe==3.0.3
-pip==26.0.1
-setuptools==82.0.1
 Werkzeug==3.1.8


### PR DESCRIPTION
## Summary

- **Dockerfile**: uv 0.11.8 バイナリを公式イメージからコピーし、`pip install` を `uv pip install --system` に変更
- **app/requirements.txt**: uv では不要な `pip` と `setuptools` を削除
- **CI**: `actions/setup-python` + `pip` を `astral-sh/setup-uv` + `uv pip install` に変更

## Test plan

- [ ] Docker イメージがビルドできることを確認
- [ ] CI の test ジョブ (pytest) がパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)